### PR TITLE
fix timeformat bug

### DIFF
--- a/src/EOS.Client/Models/EosDateTimeConverter.cs
+++ b/src/EOS.Client/Models/EosDateTimeConverter.cs
@@ -16,7 +16,8 @@ namespace EOS.Client.Models
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var utcDate = $"{reader.Value}Z";
+            string timeString = reader.Value.ToString();
+            var utcDate =timeString.EndsWith("M", StringComparison.OrdinalIgnoreCase)? timeString: $"{reader.Value}Z";
             return DateTime.Parse(utcDate);
         }
     }


### PR DESCRIPTION
sometimes, the EOS API will return time string like "3/17/2019 5:50:57 PM"